### PR TITLE
[BUGFIX] Fix crash when using the app.

### DIFF
--- a/ReadSMC/AppleSMC.h
+++ b/ReadSMC/AppleSMC.h
@@ -11,13 +11,15 @@
 #define APPLE_SMC_PROTOCOL_GUID \
 { 0x17407e5a, 0xaf6c, 0x4ee8, {0x98, 0xa8, 0x00, 0x21, 0x04, 0x53, 0xcd, 0xd9} }
 
-typedef EFI_STATUS (EFIAPI* APPLE_SMC_READ_DATA)(IN VOID *This, IN UINT32 DataId, IN UINT32 DataLength, OUT VOID* DataBuffer);
+typedef struct _APPLE_SMC_PROTOCOL APPLE_SMC_PROTOCOL;
 
-typedef struct _APPLE_SMC_PROTOCOL
+typedef EFI_STATUS (EFIAPI* APPLE_SMC_READ_DATA)(IN APPLE_SMC_PROTOCOL *This, IN UINT32 DataId, IN UINT32 DataLength, OUT VOID* DataBuffer);
+
+struct _APPLE_SMC_PROTOCOL
 {
 	UINT64 Signature;
 	APPLE_SMC_READ_DATA ReadData;
-} APPLE_SMC_PROTOCOL;
+};
 
 extern EFI_GUID gAppleSMCProtocolGuid;
 

--- a/ReadSMC/ReadSMC.c
+++ b/ReadSMC/ReadSMC.c
@@ -141,7 +141,7 @@ ShellAppMain (
 
     SMCKD = AllocateZeroPool(SMCKL);
 
-    Status = SMCP->ReadData(SMCKD, SMCKID, SMCKL, SMCKD);
+    Status = SMCP->ReadData(SMCP, SMCKID, SMCKL, SMCKD);
 
     if (EFI_ERROR(Status))
     {


### PR DESCRIPTION
Change 'This' type from VOID \* to APPLE_SMC_PROTOCOL *.
Pass the correct 'This' pointer to APPLE_SMC_READ_DATA.
